### PR TITLE
added matplotlib inline

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -116,6 +116,7 @@
    "source": [
     "# Output current version of software tools used in this course:\n",
     "\n",
+    "%matplotlib inline\n",
     "import sys\n",
     "import numpy as np\n",
     "import pandas as pd\n",


### PR DESCRIPTION
One possible way to fix #2 is to add `%matplotlib inline` before `import matplotlib`:

``` python
%matplotlib inline
import matplotlib as mpl
```
